### PR TITLE
Include the null terminator when processing the result of wget.callba…

### DIFF
--- a/src/luahooks.c
+++ b/src/luahooks.c
@@ -489,7 +489,7 @@ luahooks_lookup_host (const char *host)
         return NULL;
 
       /* Copy to the buffer. */
-      size_t ret_l = lua_strlen(lua, -1);
+      size_t ret_l = lua_strlen(lua, -1) + 1;
       ret_l = (ret_l <= MAX_HOST_LENGTH) ? ret_l : MAX_HOST_LENGTH;
       strncpy (lookup_host_result, ret, ret_l);
 


### PR DESCRIPTION
…cks.lookup_host

Before, wget-lua did not copy over the null terminator with the rest of the returned string. As a result, lookup_host became unreliable when it returned strings of different lengths, as the buffer is reused.
This required using a trick to get the returned string to a constant length, as can be seen in https://github.com/ArchiveTeam/galerie-cz-grab/commit/5a85371cd6fb28fe6bc83a79a2b0bc8a0a357c6f