### PR TITLE
Abort on Lua errors by default

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -264,6 +264,9 @@ static const struct {
   { "method",           &opt.method,            cmd_string_uppercase },
   { "mirror",           NULL,                   cmd_spec_mirror },
   { "netrc",            &opt.netrc,             cmd_boolean },
+#ifdef ENABLE_LUA
+  { "noabortonluaerror", &opt.no_abort_on_lua_error, cmd_boolean },
+#endif
   { "noclobber",        &opt.noclobber,         cmd_boolean },
   { "noconfig",         &opt.noconfig,          cmd_boolean },
   { "noparent",         &opt.no_parent,         cmd_boolean },

--- a/src/luahooks.c
+++ b/src/luahooks.c
@@ -108,6 +108,7 @@ handle_lua_error (int res)
       if (!opt.no_abort_on_lua_error)
         {
             fflush(stdout);
+            fflush(stderr);
             abort();
         }
     }

--- a/src/luahooks.c
+++ b/src/luahooks.c
@@ -105,6 +105,11 @@ handle_lua_error (int res)
             printf ("Lua error: %s.\n", msg);
         }
       free (msg);
+      if (!opt.no_abort_on_lua_error)
+        {
+            fflush(stdout);
+            abort();
+        }
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -378,6 +378,9 @@ static struct cmdline_option option_data[] =
     { "mirror", 'm', OPT_BOOLEAN, "mirror", -1 },
     { "netrc", 0, OPT_BOOLEAN, "netrc", -1 },
     { "no", 'n', OPT__NO, NULL, required_argument },
+#ifdef ENABLE_LUA
+    { "no-abort-on-lua-error", 0, OPT_BOOLEAN, "noabortonluaerror", -1},
+#endif
     { "no-clobber", 0, OPT_BOOLEAN, "noclobber", -1 },
     { "no-config", 0, OPT_BOOLEAN, "noconfig", -1},
     { "no-parent", 0, OPT_BOOLEAN, "noparent", -1 },
@@ -775,6 +778,10 @@ Download:\n"),
 #ifdef ENABLE_XATTR
     N_("\
        --xattr                     turn on storage of metadata in extended file attributes\n"),
+#endif
+#ifdef ENABLE_LUA
+    N_("\
+       --no-abort-on-lua-error     continue after a Lua execution error, instead of aborting\n"),
 #endif
     "\n",
 

--- a/src/options.h
+++ b/src/options.h
@@ -343,6 +343,7 @@ struct options
 
 #ifdef ENABLE_LUA
   char *lua_filename;		        /* Lua script filename */
+  bool no_abort_on_lua_error;       /* Whether to ignore Lua script errors. */
 #endif
 
   bool report_bps;              /*Output bandwidth in bits format*/


### PR DESCRIPTION
--no-abort-on-lua-error can go back to the old behavior.