### PR TITLE
Fix WARC CDX writing

### DIFF
--- a/src/warc.c
+++ b/src/warc.c
@@ -1886,7 +1886,7 @@ warc_write_cdx_record (const char *url, const char *timestamp_str,
                timestamp_str_cdx, url, mime_type, response_code, checksum,
                tmp_location, offset_string, warc_current_filename,
                response_uuid) < 0
-      || fflush (warc_current_cdx_file) != 0);
+      || fflush (warc_current_cdx_file) != 0)
     warc_write_ok = false;
 
   xfree (tmp_location);


### PR DESCRIPTION
Commit fd873c1ecb96467e633f145aeaad256ca36fcd63 introduced a bug in the CDX file writing logic that prevents the use of the `--warc-cdx` option.

Any use of this option errors with:

> Cannot write to WARC file.

This appears to be due to a misplaced semicolon on an `if` statement:

```c
if ( ... logic ... );
  warc_write_ok = false;
```

This always sets `warc_write_ok` to be false, regardless of the outcome of the logic check in the `if` statement.