### PR TITLE
Add ARM64 support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,9 @@
 ---
 kind: pipeline
 name: default
+platform:
+  os: linux
+  arch: amd64
 steps:
 - name: docker_openssl
   image: plugins/docker
@@ -18,6 +21,9 @@ steps:
     - ${DRONE_BRANCH}-openssl
     build_args:
     - TLSTYPE=openssl
+    platforms:
+    - linux/amd64
+    - linux/arm64
 - name: docker_gnutls
   image: plugins/docker
   settings:
@@ -34,6 +40,9 @@ steps:
     - ${DRONE_BRANCH}-gnutls
     build_args:
     - TLSTYPE=gnutls
+    platforms:
+    - linux/amd64
+    - linux/arm64
 - name: docker_nss
   image: plugins/docker
   settings:
@@ -50,3 +59,6 @@ steps:
     - ${DRONE_BRANCH}-nss
     build_args:
     - TLSTYPE=nss
+    platforms:
+    - linux/amd64
+    - linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,11 @@ RUN set -eux \
       cp -a /usr/include/nspr/. /usr/local/include/nspr/; \
       rm -f ../dist/Release/lib/*.TOC; \
       cp -a ../dist/Release/lib/* /usr/local/lib/; \
-      cp -a /usr/lib/x86_64-linux-gnu/nss/libnsspem.so* /usr/local/lib/; \
-      cp -a /lib/x86_64-linux-gnu/libnspr4.so* /usr/local/lib/; \
-      cp -a /lib/x86_64-linux-gnu/libplc4.so* /usr/local/lib/; \
-      cp -a /lib/x86_64-linux-gnu/libplds4.so* /usr/local/lib/; \
+      MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH); \
+      cp -a /usr/lib/${MULTIARCH}/nss/libnsspem.so* /usr/local/lib/; \
+      cp -a /usr/lib/${MULTIARCH}/libnspr4.so* /usr/local/lib/; \
+      cp -a /usr/lib/${MULTIARCH}/libplc4.so* /usr/local/lib/; \
+      cp -a /usr/lib/${MULTIARCH}/libplds4.so* /usr/local/lib/; \
     fi
 RUN cd /tmp \
  && wget https://github.com/vapier/ncompress/archive/c576364d691df490ec1841d028c7bece2b523c58.tar.gz -O ncompress.tar.gz \


### PR DESCRIPTION
The NSS build in the Dockerfile hardcodes `x86_64-linux-gnu` library paths, so it can't build on ARM64. This replaces those with `dpkg-architecture -qDEB_HOST_MULTIARCH` which resolves to the right path on any architecture.

Also adds `linux/arm64` to the Drone CI platform list for all three TLS variants.

Part of ArchiveTeam/warrior-dockerfile#56